### PR TITLE
chore: release v0.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testcontainers-redpanda-rs"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 license = "MIT"
 description = "Unofficial redpanda test container"


### PR DESCRIPTION



## 🤖 New release

* `testcontainers-redpanda-rs`: 0.11.0 -> 0.11.1

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).